### PR TITLE
 npm run scripts: wait for the spawned process to finish 

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "build:js-dev": "webpack --mode development",
     "build:js": "webpack --mode production",
     "build:py": "node ./extract-meta src/lib/components > my_dash_component/metadata.json && copyfiles package.json my_dash_component && python -c \"import dash; dash.development.component_loader.generate_classes('my_dash_component', 'my_dash_component/metadata.json')\"",
-    "build:all": "npm run build:js & npm run build:py",
-    "build:all-dev": "npm run build:js-dev & npm run build:py"
+    "build:all": "npm run build:js & npm run build:py; wait",
+    "build:all-dev": "npm run build:js-dev & npm run build:py; wait"
   },
   "author": "my-name my-email",
   "license": "my-license",


### PR DESCRIPTION
`&` causes the command to be run in the background. whereas `&&` waits for the command to exit successfully.

As far as I can tell, it could have been intended to use `&`. If that's the cause using `wait` might be beneficial as (1) it shows the clear intention of running programs in parallel to the reader and (2) the CLI actually waits for the processes to finish and not suddenly dumps texts after a few seconds.
Though I'm not sure whether `wait` will work on Windows.
A better alternative might be [concurrently](https://www.npmjs.com/package/concurrently).

See also:
- https://stackoverflow.com/questions/25669540/what-is-the-difference-between-double-ampersand-and-semicolon-in-linux
- http://tldp.org/LDP/abs/html/x9644.html