### PR TITLE
fix webpack-cli error by upgrading the version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-docgen": "^2.20.1",
     "style-loader": "^0.21.0",
     "webpack": "^4.8.3",
-    "webpack-cli": "^2.1.3",
+    "webpack-cli": "^3.1.0",
     "webpack-serve": "^1.0.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
The previous version was giving rise to an error upon `npm run build:js-dev`