### PR TITLE
[WIP] Fix error when using Anaconda

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -62,7 +62,7 @@ if install_deps != 'True':
     sys.exit(0)
 
 # Create a virtual env
-if sys.version.split(' ')[0] > '3.2':
+if sys.version.split(' ')[0] > '3.2' and 'Anaconda' not in sys.version:
     venv = 'python -m venv venv'
 else:
     venv = 'virtualenv venv'


### PR DESCRIPTION
This PR attempts to fix the problem related with virtualenv in Python when using Anaconda (please refer to https://github.com/plotly/dash-component-boilerplate/issues/23). Whereas
```
venv = 'python -m venv venv' 
```
throws an error when using anaconda, this seems to work:
```
venv = 'virtualenv venv'
```
This worked well for me. I believe further testing is required to make sure this is consistent with other anaconda versions.