### PR TITLE
Correct import statement for component into App

### DIFF
--- a/{{cookiecutter.project_shortname}}/src/demo/App.js
+++ b/{{cookiecutter.project_shortname}}/src/demo/App.js
@@ -1,7 +1,7 @@
 /* eslint no-magic-numbers: 0 */
 import React, {Component} from 'react';
 
-import {{cookiecutter.component_name}} from '../lib';
+import { {{cookiecutter.component_name}} } from '../lib';
 
 class App extends Component {
 


### PR DESCRIPTION
The component was showing up as `undefined` straight out of the box -- looks like since the export is done as an `export { ComponentName }`, we'll need a `import { ComponentName }` to correspond.