### PR TITLE
Remove react and reactDOM from dependencies.

### DIFF
--- a/{{cookiecutter.project_shortname}}/package.json
+++ b/{{cookiecutter.project_shortname}}/package.json
@@ -34,9 +34,7 @@
     "style-loader": "^0.21.0",
     "webpack": "^4.20.2",
     "webpack-cli": "^3.1.1",
-    "webpack-serve": "^1.0.2"
-  },
-  "peerDependencies": {
+    "webpack-serve": "^1.0.2",
     "react": ">=0.14",
     "react-dom": ">=0.14"
   },

--- a/{{cookiecutter.project_shortname}}/package.json
+++ b/{{cookiecutter.project_shortname}}/package.json
@@ -15,9 +15,7 @@
   "author": "{{ cookiecutter.author_name }} {{ cookiecutter.author_email }}",
   "license": "{% set _license_identifiers = {'MIT License': 'MIT','BSD License': 'BSD','ISC License': 'ISC','Apache Software License 2.0': 'Apache-2.0','GNU General Public License v3': 'GPL-3.0','Not open source': ''} %}{{ _license_identifiers[cookiecutter.license] }}",
   "dependencies": {
-    "ramda": "^0.25.0",
-    "react": "15.4.2",
-    "react-dom": "15.4.2"
+    "ramda": "^0.25.0"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",


### PR DESCRIPTION
They are `peerDependencies` served by dash and included in the `_js_dist` of `dash-renderer`.

Closes #39