### PR TITLE
Fix venv/bin/activate build:py.

### DIFF
--- a/{{cookiecutter.project_shortname}}/package.json
+++ b/{{cookiecutter.project_shortname}}/package.json
@@ -9,7 +9,7 @@
     "prepublish": "npm run validate-init",
     "build:js-dev": "webpack --mode development",
     "build:js": "webpack --mode production",
-    "build:py": "(. venv/bin/activate || venv\\scripts\\activate) && dash-generate-components ./src/lib/components {{ cookiecutter.project_shortname }}",
+    "build:py": "(. venv/bin/activate || venv\\scripts\\activate && dash-generate-components ./src/lib/components {{ cookiecutter.project_shortname }})",
     "build:all": "npm run build:js && npm run build:js-dev && npm run build:py"
   },
   "author": "{{ cookiecutter.author_name }} {{ cookiecutter.author_email }}",


### PR DESCRIPTION
Had trouble running the `build:py` command from a non activated environment (pycharm run) on xubuntu 18.04.