### PR TITLE
Update pytest-dash

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 testpaths = tests/
+log_cli=true
+log_format = %(asctime)s %(levelname)s %(message)s
+log_date_format = %Y-%m-%d %H:%M:%S

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,4 +4,4 @@ dash-core-components
 pytest
 pytest-cookies
 pytest-selenium
-pytest-dash
+pytest-dash==0.2.0rc3

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,4 +4,4 @@ dash-core-components
 pytest
 pytest-cookies
 pytest-selenium
-pytest-dash==0.2.0rc3
+pytest-dash>=1.0.1

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,6 +1,4 @@
 import json
-import os
-import sys
 
 
 default_context = {

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2,8 +2,10 @@ import shutil
 import time
 import sys
 
+from pytest_dash.utils import import_app
 
-def test_install(cookies, dash_app, selenium):
+
+def test_install(cookies, dash_threaded, selenium):
     results = cookies.bake(extra_context={
         'project_name': 'Test Component',
         'author_name': 'test',
@@ -15,7 +17,7 @@ def test_install(cookies, dash_app, selenium):
     sys.path.insert(0, str(results.project))
 
     # Test that `usage.py` works after building the default component.
-    dash_app(str(results.project.join('usage.py')))
+    dash_threaded(import_app(str(results.project.join('usage.py'))))
 
     time.sleep(1)
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2,7 +2,11 @@ import shutil
 import time
 import sys
 
-from pytest_dash.utils import import_app
+from pytest_dash.utils import (
+    import_app,
+    wait_for_text_to_equal,
+    wait_for_element_by_css_selector
+)
 
 
 def test_install(cookies, dash_threaded, selenium):
@@ -21,16 +25,18 @@ def test_install(cookies, dash_threaded, selenium):
 
     time.sleep(1)
 
-    input_component = selenium.find_element_by_xpath(
-        '//div[@id="input"]/input')
+    input_component = wait_for_element_by_css_selector(
+        selenium,
+        '#input > input'
+    )
     input_component.clear()
     input_component.send_keys('Hello dash component')
 
-    time.sleep(2)
-
-    output = selenium.find_element_by_id('output')
-
-    assert output.text == 'You have entered Hello dash component'
+    wait_for_text_to_equal(
+        selenium,
+        '#output',
+        'You have entered Hello dash component'
+    )
 
     node_modules = str(results.project.join('node_modules'))
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,6 +1,6 @@
 import shutil
-import time
 import sys
+
 
 from pytest_dash.utils import (
     import_app,
@@ -21,9 +21,7 @@ def test_install(cookies, dash_threaded, selenium):
     sys.path.insert(0, str(results.project))
 
     # Test that `usage.py` works after building the default component.
-    dash_threaded(import_app(str(results.project.join('usage.py'))))
-
-    time.sleep(1)
+    dash_threaded(import_app('usage'))
 
     input_component = wait_for_element_by_css_selector(
         selenium,

--- a/{{cookiecutter.project_shortname}}/tests/requirements.txt
+++ b/{{cookiecutter.project_shortname}}/tests/requirements.txt
@@ -12,4 +12,4 @@ percy
 selenium
 flake8
 pylint
-pytest-dash==0.2.0rc3
+pytest-dash>=1.0.1

--- a/{{cookiecutter.project_shortname}}/tests/requirements.txt
+++ b/{{cookiecutter.project_shortname}}/tests/requirements.txt
@@ -12,4 +12,4 @@ percy
 selenium
 flake8
 pylint
-pytest-dash
+pytest-dash==0.2.0rc3

--- a/{{cookiecutter.project_shortname}}/tests/test_usage.py
+++ b/{{cookiecutter.project_shortname}}/tests/test_usage.py
@@ -11,7 +11,7 @@ def test_render_component(dash_threaded, selenium):
     # dash_threaded is a fixture by pytest-dash
     # It will load a py file containing a Dash instance named `app`
     # and start it in a thread.
-    app = import_app('usage.py')
+    app = import_app('usage')
     dash_threaded(app)
 
     # Get the generated component input with selenium

--- a/{{cookiecutter.project_shortname}}/tests/test_usage.py
+++ b/{{cookiecutter.project_shortname}}/tests/test_usage.py
@@ -1,13 +1,16 @@
 import time
 
+from pytest_dash.utils import import_app
+
 
 # Basic test for the component rendering.
-def test_render_component(dash_subprocess, selenium):
+def test_render_component(dash_threaded, selenium):
     # Start a dash app contained in `usage.py`
-    # dash_app is a fixture by pytest-dash
+    # dash_threaded is a fixture by pytest-dash
     # It will load a py file containing a Dash instance named `app`
     # and start it in a thread.
-    dash_subprocess('usage')
+    app = import_app('usage.py')
+    dash_threaded(app)
 
     # Get the generated component input with selenium
     # The html input will be a children of the #input dash component

--- a/{{cookiecutter.project_shortname}}/tests/test_usage.py
+++ b/{{cookiecutter.project_shortname}}/tests/test_usage.py
@@ -26,6 +26,6 @@ def test_render_component(dash_threaded, selenium):
     # Send keys to the custom input.
     my_component.send_keys('Hello dash')
 
-    # Wait for the text to equal, if after 10 second (default) the is not
-    # equal it will fail the test.
+    # Wait for the text to equal, if after the timeout (default 10 seconds)
+    # the text is not equal it will fail the test.
     wait_for_text_to_equal(selenium, '#output', 'You have entered Hello dash')

--- a/{{cookiecutter.project_shortname}}/tests/test_usage.py
+++ b/{{cookiecutter.project_shortname}}/tests/test_usage.py
@@ -2,12 +2,12 @@ import time
 
 
 # Basic test for the component rendering.
-def test_render_component(dash_app, selenium):
+def test_render_component(dash_subprocess, selenium):
     # Start a dash app contained in `usage.py`
     # dash_app is a fixture by pytest-dash
     # It will load a py file containing a Dash instance named `app`
     # and start it in a thread.
-    app = dash_app('usage.py')
+    dash_subprocess('usage')
 
     # Get the generated component input with selenium
     # The html input will be a children of the #input dash component

--- a/{{cookiecutter.project_shortname}}/tests/test_usage.py
+++ b/{{cookiecutter.project_shortname}}/tests/test_usage.py
@@ -1,6 +1,8 @@
-import time
-
-from pytest_dash.utils import import_app
+from pytest_dash.utils import (
+    import_app,
+    wait_for_text_to_equal,
+    wait_for_element_by_css_selector
+)
 
 
 # Basic test for the component rendering.
@@ -14,7 +16,7 @@ def test_render_component(dash_threaded, selenium):
 
     # Get the generated component input with selenium
     # The html input will be a children of the #input dash component
-    my_component = selenium.find_element_by_css_selector('#input > input')
+    my_component = wait_for_element_by_css_selector(selenium, '#input > input')
 
     assert 'my-value' == my_component.get_attribute('value')
 
@@ -24,11 +26,6 @@ def test_render_component(dash_threaded, selenium):
     # Send keys to the custom input.
     my_component.send_keys('Hello dash')
 
-    # Wait for the output callback to complete.
-    time.sleep(1)
-
-    # Get the output component.
-    output = selenium.find_element_by_id('output')
-
-    # assert the text has changed
-    assert output.text == 'You have entered Hello dash'
+    # Wait for the text to equal, if after 10 second (default) the is not
+    # equal it will fail the test.
+    wait_for_text_to_equal(selenium, '#output', 'You have entered Hello dash')


### PR DESCRIPTION
Replace pytest-dash fixtures that were renamed in pytest-dash 1.0.0

The tests are still running threaded as I couldn't make the subprocess test work on circleci.

@valentijnnieman Please review.