### PR TITLE
Fix start script

### DIFF
--- a/{{cookiecutter.project_shortname}}/index.html
+++ b/{{cookiecutter.project_shortname}}/index.html
@@ -5,6 +5,6 @@
     </head>
     <body>
         <div id='root'></div>
-        <script src="/output.js"></script>
+        <script src="/{{ cookiecutter.project_shortname }}/output.js"></script>
     </body>
 </html>

--- a/{{cookiecutter.project_shortname}}/package.json
+++ b/{{cookiecutter.project_shortname}}/package.json
@@ -14,7 +14,7 @@
 {%- endif %}
   "main": "build/index.js",
   "scripts": {
-    "start": "webpack-serve ./webpack.serve.config.js --open",
+    "start": "webpack-serve --config ./webpack.serve.config.js --open",
     "validate-init": "python _validate_init.py",
     "prepublish": "npm run validate-init",
     "build:js": "webpack --mode production",


### PR DESCRIPTION
I tried to run `npm run start` and found the webpage didn't work. It seems that webpack-serve needs to have a --config flag set in order for it to look at the file it is provided with. The dev version of the built file appears in a subdirectory instead of the root directory so I updated the index.html to point at the right place.

Unrelated to the PR: After running cookie cutter I had to manually `npm install http2` to make `npm run start` work (using node 8.4.0).