### PR TITLE
Make dash[dev] a requirement

### DIFF
--- a/{{cookiecutter.project_shortname}}/requirements.txt
+++ b/{{cookiecutter.project_shortname}}/requirements.txt
@@ -1,2 +1,2 @@
 # dash is required to call `build:py`
-dash>=1.0.2
+dash[dev]>=1.0.2


### PR DESCRIPTION
Currently using `cookiecutter` on this project as documented in the readme fails due to `PyYAML` not being installed as a dependency, see #81 and #84 

This is because `PyYAML` was removed as a standard install requirement in `dash` [here](https://github.com/plotly/dash/pull/874).

This PR fixes this by simply making `dash[dev]` a requirement rather than `dash`. This is an alternative fix to #83 which allows `dash` to manage its own dependencies rather than adding PyYAML as a specific requirement of the boilerplate.