### PR TITLE
Replace all instances of plot.ly with plotly.com.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: https://plot.ly/products/consulting-and-oem/
+custom: https://plotly.com/products/consulting-and-oem/

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ to generate the components in the `build:py_and_r` script of the generated
 
 ## More Resources
 
-- Learn more about Dash: https://dash.plot.ly
+- Learn more about Dash: https://dash.plotly.com
 - Questions about this project? Create an issue: https://github.com/plotly/dash-component-boilerplate/issues/new
 - Watch the [component boilerplate repository](https://github.com/plotly/dash-component-boilerplate) to stay informed of changes to our components.
-- [React guide for Python developers](https://dash.plot.ly/react-for-python-developers)
-- Need help with your component? View the Dash Community Forum: https://community.plot.ly/c/dash
+- [React guide for Python developers](https://dash.plotly.com/react-for-python-developers)
+- Need help with your component? View the Dash Community Forum: https://community.plotly.com/c/dash
 - Examples of Dash component libraries include `dash-core-components`: https://github.com/plotly/dash-core-components and `dash-html-components`: https://github.com/plotly/dash-html-components.
 - To get a feel for what's involved in creating a component, read through the [README.MD file that this cookiecutter project generates](%7B%7Bcookiecutter.project_shortname%7D%7D/README.md)

--- a/{{cookiecutter.project_shortname}}/README.md
+++ b/{{cookiecutter.project_shortname}}/README.md
@@ -3,7 +3,7 @@
 {{cookiecutter.project_name}} is a Dash component library.
 
 Get started with:
-1. Install Dash and its dependencies: https://dash.plot.ly/installation
+1. Install Dash and its dependencies: https://dash.plotly.com/installation
 2. Run `python usage.py`
 3. Visit http://localhost:8050 in your web browser
 
@@ -88,7 +88,7 @@ If you have selected install_dependencies during the prompt, you can skip this p
         ```
         _Publishing your component to NPM will make the JavaScript bundles available on the unpkg CDN. By default, Dash serves the component library's CSS and JS locally, but if you choose to publish the package to NPM you can set `serve_locally` to `False` and you may see faster load times._
 
-5. Share your component with the community! https://community.plot.ly/c/dash
+5. Share your component with the community! https://community.plotly.com/c/dash
     1. Publish this repository to GitHub
     2. Tag your GitHub repository with the plotly-dash tag so that it appears here: https://github.com/topics/plotly-dash
-    3. Create a post in the Dash community forum: https://community.plot.ly/c/dash
+    3. Create a post in the Dash community forum: https://community.plotly.com/c/dash


### PR DESCRIPTION
### About 
Related to https://github.com/plotly/dash-core/issues/152