### PR TITLE
Add `npm run build:backends`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To use this boilerplate:
 
 Installing the dependencies can take a long time. They will be installed in a
 folder named `venv`, created by virtualenv. This ensures that dash is installed
-to generate the components in the `build:py_and_r` script of the generated
+to generate the components in the `build:backends` script of the generated
 `package.json`.
 
 

--- a/{{cookiecutter.project_shortname}}/package.json
+++ b/{{cookiecutter.project_shortname}}/package.json
@@ -20,8 +20,6 @@
     "build:js": "webpack --mode production",
     "build:backends": "dash-generate-components ./src/lib/components {{ cookiecutter.project_shortname }} -p package-info.json --r-prefix '{{ cookiecutter.r_prefix }}' --jl-prefix '{{ cookiecutter.jl_prefix }}'",
     "build:backends-activated": "(. venv/bin/activate || venv\\scripts\\activate && npm run build:py_and_r)",
-    "build:py_and_r": "npm run build:backends",
-    "build:py_and_r-activated": "npm run build:backends-activated",
     "build": "npm run build:js && npm run build:backends",
     "build:activated": "npm run build:js && npm run build:backends-activated"
   },

--- a/{{cookiecutter.project_shortname}}/package.json
+++ b/{{cookiecutter.project_shortname}}/package.json
@@ -18,10 +18,12 @@
     "validate-init": "python _validate_init.py",
     "prepublishOnly": "npm run validate-init",
     "build:js": "webpack --mode production",
-    "build:py_and_r": "dash-generate-components ./src/lib/components {{ cookiecutter.project_shortname }} -p package-info.json --r-prefix '{{ cookiecutter.r_prefix }}' --jl-prefix '{{ cookiecutter.jl_prefix }}'",
-    "build:py_and_r-activated": "(. venv/bin/activate || venv\\scripts\\activate && npm run build:py_and_r)",
-    "build": "npm run build:js && npm run build:py_and_r",
-    "build:activated": "npm run build:js && npm run build:py_and_r-activated"
+    "build:backends": "dash-generate-components ./src/lib/components {{ cookiecutter.project_shortname }} -p package-info.json --r-prefix '{{ cookiecutter.r_prefix }}' --jl-prefix '{{ cookiecutter.jl_prefix }}'",
+    "build:backends-activated": "(. venv/bin/activate || venv\\scripts\\activate && npm run build:py_and_r)",
+    "build:py_and_r": "npm run build:backends",
+    "build:py_and_r-activated": "npm run build:backends-activated",
+    "build": "npm run build:js && npm run build:backends",
+    "build:activated": "npm run build:js && npm run build:backends-activated"
   },
   "author": "{{ cookiecutter.author_name }} <{{ cookiecutter.author_email }}>",
   "license": "{% set _license_identifiers = {'MIT License': 'MIT','BSD License': 'BSD','ISC License': 'ISC','Apache Software License 2.0': 'Apache-2.0','GNU General Public License v3': 'GPL-3.0','Not open source': ''} %}{{ _license_identifiers[cookiecutter.license] }}",


### PR DESCRIPTION
Closes #116

Should we also remove `npm run build:py_and_r` or keep it for backward compatibility?