### PR TITLE
Remove NPM from package.json

### DIFF
--- a/{{cookiecutter.project_shortname}}/package.json
+++ b/{{cookiecutter.project_shortname}}/package.json
@@ -43,7 +43,6 @@
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-import": "^2.18.0",
     "eslint-plugin-react": "^7.14.2",
-    "npm": "^6.1.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-docgen": "^4.1.1",


### PR DESCRIPTION
As Node & NPM is listed in the requirements this isn't really needed and if a later version of NPM (i.e. 8.2.0) is present this older version would be installed. This was causing an issue for my setup as this older version isn't my mirror of NPM.

As you're using 'engines' NPM would warn if a user is using an older version.

Any question or concerns please just let me know, especially if I'm missing a part of your PR process. Cheers!