### PR TITLE
Add `ignore` to build:backends to aid discovery

### DIFF
--- a/{{cookiecutter.project_shortname}}/package.json
+++ b/{{cookiecutter.project_shortname}}/package.json
@@ -18,7 +18,7 @@
     "validate-init": "python _validate_init.py",
     "prepublishOnly": "npm run validate-init",
     "build:js": "webpack --mode production",
-    "build:backends": "dash-generate-components ./src/lib/components {{ cookiecutter.project_shortname }} -p package-info.json --r-prefix '{{ cookiecutter.r_prefix }}' --jl-prefix '{{ cookiecutter.jl_prefix }}' --ignore \\.(test|spec)\\.",
+    "build:backends": "dash-generate-components ./src/lib/components {{ cookiecutter.project_shortname }} -p package-info.json --r-prefix '{{ cookiecutter.r_prefix }}' --jl-prefix '{{ cookiecutter.jl_prefix }}' --ignore \\.test\\.",
     "build:backends-activated": "(. venv/bin/activate || venv\\scripts\\activate && npm run build:py_and_r)",
     "build": "npm run build:js && npm run build:backends",
     "build:activated": "npm run build:js && npm run build:backends-activated"

--- a/{{cookiecutter.project_shortname}}/package.json
+++ b/{{cookiecutter.project_shortname}}/package.json
@@ -18,7 +18,7 @@
     "validate-init": "python _validate_init.py",
     "prepublishOnly": "npm run validate-init",
     "build:js": "webpack --mode production",
-    "build:backends": "dash-generate-components ./src/lib/components {{ cookiecutter.project_shortname }} -p package-info.json --r-prefix '{{ cookiecutter.r_prefix }}' --jl-prefix '{{ cookiecutter.jl_prefix }}'",
+    "build:backends": "dash-generate-components ./src/lib/components {{ cookiecutter.project_shortname }} -p package-info.json --r-prefix '{{ cookiecutter.r_prefix }}' --jl-prefix '{{ cookiecutter.jl_prefix }}' --ignore \\.(test|spec)\\.",
     "build:backends-activated": "(. venv/bin/activate || venv\\scripts\\activate && npm run build:py_and_r)",
     "build": "npm run build:js && npm run build:backends",
     "build:activated": "npm run build:js && npm run build:backends-activated"


### PR DESCRIPTION
react-docgen is set to run against all jsx and js files in `extract-meta.js`, as a result any Jest test files will throw warnings.

The boilerplate was my entrypoint to dash-generate-components so it took me an embarrassingly long time to find the ignore option.

This PR adds an example ignore pattern of a common Jest test filename pattern. Hopefully it also would give users a starting point to setup their own ignore without having to determine the format / escaping.

The more complex Jest default is here: https://jestjs.io/docs/configuration#testmatch-arraystring 

Any question or concerns please just let me know, especially if I'm missing a part of your PR process. Cheers!