### PR TITLE
Add Julia's `Manifest.toml` to gitignore list

### DIFF
--- a/{{cookiecutter.project_shortname}}/.gitignore
+++ b/{{cookiecutter.project_shortname}}/.gitignore
@@ -274,3 +274,7 @@ bh_unicode_properties.cache
 # Sublime-github package stores a github token in this file
 # https://packagecontrol.io/packages/sublime-github
 GitHub.sublime-settings
+
+# Julia manifest file names
+Manifest.toml
+JuliaManifest.toml


### PR DESCRIPTION
Both names can be valid manifest file names in Julia v1.+

ref: https://pkgdocs.julialang.org/v1.7/glossary/#Glossary