### PR TITLE
add option to change port for MacOs

### DIFF
--- a/{{cookiecutter.project_shortname}}/webpack.config.js
+++ b/{{cookiecutter.project_shortname}}/webpack.config.js
@@ -3,7 +3,7 @@ const TerserPlugin = require('terser-webpack-plugin');
 const webpack = require('webpack');
 const WebpackDashDynamicImport = require('@plotly/webpack-dash-dynamic-import');
 const packagejson = require('./package.json');
-
+const { WebpackPluginServe: Serve } = require('webpack-plugin-serve');
 const dashLibraryName = packagejson.name.replace(/-/g, '_');
 
 module.exports = (env, argv) => {
@@ -28,12 +28,12 @@ module.exports = (env, argv) => {
     }
 
     let filename = (overrides.output || {}).filename;
-    if(!filename) {
+    if (!filename) {
         const modeSuffix = mode === 'development' ? 'dev' : 'min';
         filename = `${dashLibraryName}.${modeSuffix}.js`;
     }
 
-    const entry = overrides.entry || {main: './src/lib/index.js'};
+    const entry = overrides.entry || { main: './src/lib/index.js' };
 
     const devtool = overrides.devtool || 'source-map';
 
@@ -117,6 +117,11 @@ module.exports = (env, argv) => {
             new webpack.SourceMapDevToolPlugin({
                 filename: '[file].map',
                 exclude: ['async-plotlyjs']
+            }),
+            new Serve({
+                // on Mac OS change this port, since it is blocked since Big Sur
+                // ref: https://github.com/shellscape/webpack-plugin-serve/issues/222
+                port: 55555
             })
         ]
     }


### PR DESCRIPTION
On MacOS since Big Sur the default port 55555 is already in use. Therefore `npm run start` will fail, with the message: 

> Error: listen EADDRINUSE: address already in use :::55555


This PR adds the option to change the port in `webpack.config.js`