### PR TITLE
Combine adding 'shared' files with 'min' files in `_js_dist`

### DIFF
--- a/{{cookiecutter.project_shortname}}/webpack.config.js
+++ b/{{cookiecutter.project_shortname}}/webpack.config.js
@@ -28,12 +28,12 @@ module.exports = (env, argv) => {
     }
 
     let filename = (overrides.output || {}).filename;
-    if(!filename) {
+    if (!filename) {
         const modeSuffix = mode === 'development' ? 'dev' : 'min';
         filename = `${dashLibraryName}.${modeSuffix}.js`;
     }
 
-    const entry = overrides.entry || {main: './src/lib/index.js'};
+    const entry = overrides.entry || { main: './src/lib/index.js' };
 
     const devtool = overrides.devtool || 'source-map';
 
@@ -107,7 +107,7 @@ module.exports = (env, argv) => {
                         chunks: 'all',
                         minSize: 0,
                         minChunks: 2,
-                        name: '{{cookiecutter.project_shortname}}-shared'
+                        name: '{{cookiecutter.project_shortname}}.shared'
                     }
                 }
             }

--- a/{{cookiecutter.project_shortname}}/{{cookiecutter.project_shortname}}/__init__.py
+++ b/{{cookiecutter.project_shortname}}/{{cookiecutter.project_shortname}}/__init__.py
@@ -34,6 +34,8 @@ async_resources = [
     {%- endif -%}
 ]
 
+shared_resources=["min"]
+
 _js_dist = []
 
 _js_dist.extend(
@@ -70,22 +72,29 @@ _js_dist.extend(
 _js_dist.extend(
     [
         {
-            'relative_package_path': '{{cookiecutter.project_shortname}}.min.js',
+            'relative_package_path': '{{cookiecutter.project_shortname}}.{0}.js',
     {% if cookiecutter.publish_on_npm == 'True' -%}
-            'external_url': 'https://unpkg.com/{0}@{2}/{1}/{1}.min.js'.format(
-                package_name, __name__, __version__),
+            'external_url': 'https://unpkg.com/{0}@{2}/{1}/{1}.{3}.js'.format(
+                package_name, __name__, __version__,shared_resource),
     {%- endif %}
             'namespace': package_name
-        },
+        }
+        for shared_resource in shared_resources
+    ]
+)
+
+_js_dist.extend(
+    [
         {
-            'relative_package_path': '{{cookiecutter.project_shortname}}.min.js.map',
+            'relative_package_path': '{{cookiecutter.project_shortname}}.{0}.js.map',
     {% if cookiecutter.publish_on_npm == 'True' -%}
-            'external_url': 'https://unpkg.com/{0}@{2}/{1}/{1}.min.js.map'.format(
-                package_name, __name__, __version__),
+            'external_url': 'https://unpkg.com/{0}@{2}/{1}/{1}.{3}.js.map'.format(
+                package_name, __name__, __version__,shared_resource),
     {%- endif %}
             'namespace': package_name,
-            'dynamic': True
+            "dynamic": True
         }
+        for shared_resource in shared_resources
     ]
 )
 


### PR DESCRIPTION
This fixes #142 

To reduce code duplication, the `-shared` in webpack.config.js was changed to `.shared`. Then this can be combined with the extension of the `_js_dist` using the `min` version.

Since it is hard to tell if there is a shared file until it is generated, a `shared_resources` list was created that defaults to `["min"]`. If a shared file is generated, then 'shared' would need to be appended to this list. Without checking to see if a file exists, this is simplest fix I could think of.
