### PR TITLE
added automatic detection of css files

### DIFF
--- a/{{cookiecutter.project_shortname}}/MANIFEST.in
+++ b/{{cookiecutter.project_shortname}}/MANIFEST.in
@@ -6,6 +6,7 @@ include {{cookiecutter.project_shortname}}/*-shared.js
 include {{cookiecutter.project_shortname}}/*-shared.js.map
 include {{cookiecutter.project_shortname}}/metadata.json
 include {{cookiecutter.project_shortname}}/package-info.json
+recursive-include {{cookiecutter.project_shortname}} *.css
 include README.md
 include LICENSE
 include package.json

--- a/{{cookiecutter.project_shortname}}/README.md
+++ b/{{cookiecutter.project_shortname}}/README.md
@@ -52,8 +52,6 @@ If you have selected install_dependencies during the prompt, you can skip this p
     - Run the tests with `$ pytest tests`.
     - The Dash team uses these types of integration tests extensively. Browse the Dash component code on GitHub for more examples of testing (e.g. https://github.com/plotly/dash-core-components)
 - Add custom styles to your component by putting your custom CSS files into your distribution folder (`{{cookiecutter.project_shortname}}`).
-    - Make sure that they are referenced in `MANIFEST.in` so that they get properly included when you're ready to publish your component.
-    - Make sure the stylesheets are added to the `_css_dist` dict in `{{cookiecutter.project_shortname}}/__init__.py` so dash will serve them automatically when the component suite is requested.
 - [Review your code](./review_checklist.md)
 
 ### Create a production build and publish:

--- a/{{cookiecutter.project_shortname}}/{{cookiecutter.project_shortname}}/__init__.py
+++ b/{{cookiecutter.project_shortname}}/{{cookiecutter.project_shortname}}/__init__.py
@@ -89,7 +89,12 @@ _js_dist.extend(
     ]
 )
 
-_css_dist = []
+_css_dist = [
+    {
+        'relative_package_path': _os.path.relpath(_os.path.join(dirpath, filename), _basepath),
+        'namespace': package_name
+    } for dirpath, dirnames, filenames in _os.walk(_basepath) for filename in filenames if filename.endswith('.css')
+]
 
 
 for _component in __all__:


### PR DESCRIPTION
This commit adds automatic detection of css files in the distribution folder `{{cookiecutter.project_shortname}}`. The codes adds all `*.css` files to the `MANIFEST.in` file. Additionally, the code walks over the distribution folder to find each `*.css` file and append it to the `_css_dist` list in  `{{cookiecutter.project_shortname}}/__init__.py`