### PR TITLE
Fix: long_description missing in setup.py

### DIFF
--- a/{{cookiecutter.project_shortname}}/README.md
+++ b/{{cookiecutter.project_shortname}}/README.md
@@ -2,6 +2,8 @@
 
 {{cookiecutter.project_name}} is a Dash component library.
 
+{{cookiecutter.description}}
+
 Get started with:
 1. Install Dash and its dependencies: https://dash.plotly.com/installation
 2. Run `python usage.py`

--- a/{{cookiecutter.project_shortname}}/setup.py
+++ b/{{cookiecutter.project_shortname}}/setup.py
@@ -1,10 +1,11 @@
 import json
-import os
 from setuptools import setup
+from pathlib import Path
 
-
+here = Path(__file__).parent
 with open('package.json') as f:
     package = json.load(f)
+long_description = (here / 'README.md').read_text()
 
 package_name = package["name"].replace(" ", "_").replace("-", "_")
 
@@ -16,6 +17,8 @@ setup(
     include_package_data=True,
     license=package['license'],
     description=package.get('description', package_name),
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     install_requires=[],
     classifiers = [
         'Framework :: Dash',


### PR DESCRIPTION
Missing long_description in setup.py caused the package upload to pypi fail.

[Here](https://github.com/idling-mind/dash_resizable_panels/actions/runs/7053859327/job/19202013288#step:7:15) is an example.

I have also fixed the `long_description_content_type` so that the warning is also taken care.

Also, the project description is added to README.md