### PR TITLE
Bug Fix : Lazy Loader(Async) Render issue #163

### DIFF
--- a/{{cookiecutter.project_shortname}}/src/lib/LazyLoader.js
+++ b/{{cookiecutter.project_shortname}}/src/lib/LazyLoader.js
@@ -1,1 +1,3 @@
+import React from 'react';
+
 export const {{cookiecutter.component_name}} = React.lazy(() => import(/* webpackChunkName: "{{cookiecutter.component_name}}" */ './fragments/{{cookiecutter.component_name}}.react'));


### PR DESCRIPTION
I have resolved an issue that was related to the website not rendering properly for async due to import missing in LazyLoader cookiecutter_template