### PR TITLE
Fix Python version comparison logic in post-gen hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ To use this boilerplate:
 1. Install the requirements:
     ```
     $ pip install cookiecutter
-    $ pip install virtualenv
     ```
    [Node.js/npm is also required.](https://nodejs.org/en/)
 2. Run cookiecutter on the boilerplate repo:

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -58,10 +58,7 @@ if install_deps != 'True':
     sys.exit(0)
 
 # Create a virtual env
-if sys.version_info >= (3, 3):
-    venv = '{} -m venv venv'.format(sys.executable)
-else:
-    venv = 'virtualenv venv'
+venv = '{} -m venv venv'.format(sys.executable)
 
 # noinspection PyBroadException
 try:

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -58,7 +58,7 @@ if install_deps != 'True':
     sys.exit(0)
 
 # Create a virtual env
-if sys.version.split(' ')[0] > '3.2':
+if sys.version_info >= (3, 3):
     venv = '{} -m venv venv'.format(sys.executable)
 else:
     venv = 'virtualenv venv'


### PR DESCRIPTION
Issue:
The current string comparison `sys.version.split(' ')[0] > '3.2'` incorrectly evaluates to `False` for Python 3.11 (since `'1' < '2'`), causing the script to look for virtualenv instead of using the built-in `venv` module.

Proposed Change:
Use `sys.version_info >= (3, 3)` for a correct numerical comparison. This ensures modern Python environments use the native `venv` module as intended without requiring additional legacy dependencies.

Note:
While installing `virtualenv` manually can bypass the error, using `sys.version_info` is more robust to handle version checks in Python.